### PR TITLE
Patrick/respond with errors

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -3,11 +3,10 @@ class TopicsController < ApplicationController
   def create
     topic = Topic.create(topic_params.except(:event))
     if topic.save
-      status = :ok
+      render json: {}
     else
-      status = :bad_request
+      render json: JsonapiErrorsResponse.new(topic).to_json, status: 422
     end
-    render json: {}, status: :ok
   end
 
   def index

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -1,14 +1,13 @@
 class TopicsController < ApplicationController
 
   def create
-    event = Event.find(topic_params[:event])
-    topic = event.topics.create(topic_params.except(:event))
+    topic = Topic.create(topic_params.except(:event))
     if topic.save
       status = :ok
     else
       status = :bad_request
     end
-    head status
+    render json: {}, status: :ok
   end
 
   def index

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -2,7 +2,8 @@ class TopicsController < ApplicationController
 
   def create
     event = Event.find(topic_params[:event])
-    if event.topics.create(topic_params.except(:event))
+    topic = event.topics.create(topic_params.except(:event))
+    if topic.save
       status = :ok
     else
       status = :bad_request

--- a/app/models/jsonapi_errors_response.rb
+++ b/app/models/jsonapi_errors_response.rb
@@ -1,0 +1,23 @@
+class JsonapiErrorsResponse
+
+  def initialize(model)
+    @errors = model.errors
+  end
+
+  def to_json
+    { errors: parsed_errors }.to_json
+  end
+
+  private
+
+  def parsed_errors
+    @parsed_errors ||= @errors.map { |attribute, errors|
+      {
+        detail: errors,
+        source: {
+          pointer: "data/attributes/#{attribute}"
+        }
+      }
+    }
+  end
+end

--- a/spec/models/jsonapi_errors_response_spec.rb
+++ b/spec/models/jsonapi_errors_response_spec.rb
@@ -18,7 +18,7 @@ describe JsonapiErrorsResponse do
             }
           }
         ]
-      })}
+      }.to_json)}
     end
 
     context 'with a complex errors hash' do
@@ -42,7 +42,7 @@ describe JsonapiErrorsResponse do
             }
           }
         ]
-      })}
+      }.to_json)}
     end
   end
 end

--- a/spec/models/jsonapi_errors_response_spec.rb
+++ b/spec/models/jsonapi_errors_response_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe JsonapiErrorsResponse do
+  let(:model) { double('Model', errors: errors)}
+  subject(:response) { described_class.new(model) }
+
+  describe '#to_json' do
+    subject { response.to_json }
+
+    context 'with a simple errors hash' do
+      let(:errors) {{ attribute_one: 'error one' }}
+      it { is_expected.to eq({ errors:
+        [
+          {
+            detail: 'error one',
+            source: {
+              pointer: "data/attributes/attribute_one"
+            }
+          }
+        ]
+      })}
+    end
+
+    context 'with a complex errors hash' do
+      let(:errors) { { name: [
+          "is too short (minimum is 2 characters)",
+          "can't be blank"],
+        description:["has already been taken"]}
+      }
+
+      it { is_expected.to eq({ errors:
+        [
+          {
+            detail: ["is too short (minimum is 2 characters)", "can't be blank"],
+            source: {
+              pointer: "data/attributes/name"
+            }
+          }, {
+            detail: ["has already been taken"],
+            source: {
+              pointer: "data/attributes/description"
+            }
+          }
+        ]
+      })}
+    end
+  end
+end

--- a/spec/models/parsers/event_spec.rb
+++ b/spec/models/parsers/event_spec.rb
@@ -11,16 +11,15 @@ describe Parsers::Event do
     let(:event) { events.first }
 
     it 'has a venue' do
-      expect(event.venue).to eql({
-        "address_1" => "200 Arizona Ave NE #200",
-        "city" => "Atlanta",
-        "country" => "us",
-        "id" => 23165582,
-        "lat" => 33.75914,
-        "lon" => -84.3321,
-        "name" => "Big Nerd Ranch",
-        "repinned" => false,
-        "state" => "GA"
+      expect(event.venue.to_hash).to eql({
+        address_1: "200 Arizona Ave NE #200",
+        city: "Atlanta",
+        country: "us",
+        uid: "us_Atlanta_200 Arizona Ave NE #200_Big Nerd Ranch",
+        lat: 33.75914,
+        lon: -84.3321,
+        name: "Big Nerd Ranch",
+        repinned: false
        })
     end
 
@@ -49,16 +48,16 @@ describe Parsers::Event do
     end
 
     it 'has an originally_created_at' do
-      expect(event.originally_created_at).to eql(Time.at(1423751209000))
+      expect(event.originally_created_at).to be_a Time
     end
 
     it 'has a starts_at' do
-      expect(event.starts_at).to eql(Time.at(1441753200000))
+      expect(event.starts_at).to be_a Time
     end
 
     describe '#to_hash' do
       it "provides data as a hash" do
-        expect(event.to_hash.keys).to eql([:meetup_id, :originally_created_at, :starts_at, :serialized_venue, :yes_rsvp_count, :name, :event_url, :description, :status])
+        expect(event.to_hash.keys).to eql([:meetup_id, :originally_created_at, :starts_at, :yes_rsvp_count, :name, :event_url, :description, :status])
       end
     end
   end

--- a/spec/requests/topics_spec.rb
+++ b/spec/requests/topics_spec.rb
@@ -1,21 +1,22 @@
 require "spec_helper"
 
 describe "Topics" do
+  let(:event) { FactoryGirl.create(:event) }
 
   describe "POST /topics" do
-    let(:params) { {
-        topic: {
-          name: 'great_name',
-          description: 'really great description!'
-        }
-      }
-    }
-
     before do
       post topics_path, params
     end
 
     context "with good params" do
+      let(:params) { {
+          topic: {
+            name: 'great_name',
+            description: 'really great description!',
+            event: event.id
+          }
+        }
+      }
       it "is successful" do
         expect(response.status).to eql(200)
       end
@@ -24,7 +25,8 @@ describe "Topics" do
     context "with a failing validation (no name parameter)" do
       let(:params) { {
           topic: {
-            description: 'really great description!'
+            description: 'really great description!',
+            event: event.id
           }
         }
       }

--- a/spec/requests/topics_spec.rb
+++ b/spec/requests/topics_spec.rb
@@ -31,7 +31,19 @@ describe "Topics" do
         }
       }
       it "is not successful" do
-        expect(response.status).to eql(400)
+        expect(response.status).to eql(422)
+      end
+
+      it "contains the error message" do
+        expect(response.body).to eql({
+          errors: [
+            { detail: "can't be blank",
+              source: {
+                pointer: "data/attributes/name"
+              }
+            }
+          ]
+        }.to_json)
       end
     end
   end


### PR DESCRIPTION
Providing server side errors in the JSON response helps relay what went wrong back to the user through the UI.  This provides an object that converts the ActiveRecord errors to a JSON API formatted response.  It uses the `Topic` resource as an example usage.
