### PR TITLE
Ignore API key in cassette URL matching

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -66,5 +66,9 @@ RSpec.configure do |config|
     c.hook_into :webmock # or :fakeweb
     c.ignore_localhost = true
     c.configure_rspec_metadata!
+    c.default_cassette_options = {
+      match_requests_on: [:method,
+                          VCR.request_matchers.uri_without_param(:key)]
+    }
   end
 end


### PR DESCRIPTION
As @gschorkopf mentions in #18, VCR throws up when you run the specs.

The current cassettes are recorded using someone's API key (maybe @pdougall1). When you use another API key, VCR is unable to match the requests against the recorded cassettes.

This lets VCR match requests regardless of the API key being used.

Whoever recorded the cassettes should probably change their API key, and we should work on a way to keep them from being recorded :angel:
